### PR TITLE
Link post-type, MailChimp padding, archive filter

### DIFF
--- a/_posts/link/2016-02-21-test-post.markdown
+++ b/_posts/link/2016-02-21-test-post.markdown
@@ -1,0 +1,13 @@
+---
+layout: post
+title:  "TEST POST"
+date:   2015-02-05 19:14:46
+artist: jeff-berlin
+author: anthony-garone
+category: link
+oneliner: "Blah blah blah"
+front_page: yes
+draft: no
+icon: fa-github-square
+link: http://www.example.com
+---

--- a/css/make-weird-music-main.scss
+++ b/css/make-weird-music-main.scss
@@ -276,6 +276,14 @@ blockquote p:last-child, #more-content p:last-child, .ad p:last-child {
   background-color: #891579;
 }
 
+.menu .link {
+  background-color: #222222;
+}
+
+.menu .link:hover {
+  background-color: #000000;
+}
+
 .menu .image-wrap {
   @include flexbox();
   margin-right: 2%;
@@ -328,6 +336,19 @@ blockquote p:last-child, #more-content p:last-child, .ad p:last-child {
 .menu a .share .summary,
 .menu a .share .sponsor {
   color: #ffef8a;
+}
+
+.menu a .link {
+  padding: 15px;
+  i.link-icon,
+  div.link-content {
+    margin: auto 0;
+  }
+  i.link-icon {
+    height: 100%;
+    width: 80px;
+    font-size: 70px;
+  }
 }
 
 .page {
@@ -390,19 +411,19 @@ blockquote p:last-child, #more-content p:last-child, .ad p:last-child {
 }
 
 .video-wrapper {
-	position: relative;
-	padding-bottom: 56.25%; /* 16:9 */
-	padding-top: 25px;
-	height: 0;
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 */
+  padding-top: 25px;
+  height: 0;
   margin-bottom: 1em;
 }
 
 .video-wrapper iframe {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .important {
@@ -510,6 +531,14 @@ img.bg-dark {
 
 #artist-table a:hover {
   color: orange;
+}
+
+#mc_embed_signup {
+  margin: 0;
+  padding: 0;
+  form {
+    padding: 0 !important;
+  }
 }
 
 @media (max-width: 1600px) and (min-width: 1100px) {

--- a/discover.html
+++ b/discover.html
@@ -1,0 +1,39 @@
+---
+layout: splash
+title: Discover
+artist: mwm
+author: anthony-garone
+image:
+permalink: /archive/discover
+seo_description:
+seo_keywords:
+---
+
+{% for post in site.posts %}
+  {% if post.front_page == false or post.draft == true %}
+    {% continue %}
+  {% endif %}
+  {% if post.category == 'discover' %}
+    <a href="{{ post.url }}">
+      <article class="{{ post.category }} story">
+        <div class="image-wrap">
+          <img src="{{ site.data.artists.mwm.art_prod }}{{ post.artist }}/{{ post.image }}.svg" />
+        </div>
+
+        <div class="story-text">
+          <h2><span>{{ post.category }}: </span>{% if post.category == "interview" and post.member %}{{ post.member }}{% elsif post.category == "interview" or post.category == "discover" %}{{ site.data.artists[post.artist].name }}{% else %}{{ post.title }}{% endif %}</h2>
+          {% if post.oneliner %}<p class="oneliner">{{ post.oneliner }}</p>{% endif %}
+          {% if post.sponsors %}<p class="sponsor">Sponsored by: {{ post.sponsors }}</p>{% endif %}
+      </div>
+      </article>
+    </a>
+    {% endif %}
+{% endfor %}
+<a href="/archive">
+  <article class="index story">
+    <h2><span>More: </span>Content Archive</h2>
+    <p class="oneliner">Check the archive for lots more content!</p>
+  </article>
+</a>
+
+<!-- <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p> -->

--- a/gear.html
+++ b/gear.html
@@ -1,0 +1,39 @@
+---
+layout: splash
+title: Gear
+artist: mwm
+author: anthony-garone
+image:
+permalink: /archive/gear
+seo_description:
+seo_keywords:
+---
+
+{% for post in site.posts %}
+  {% if post.front_page == false or post.draft == true %}
+    {% continue %}
+  {% endif %}
+  {% if post.category == 'gear' %}
+    <a href="{{ post.url }}">
+      <article class="{{ post.category }} story">
+        <div class="image-wrap">
+          <img src="{{ site.data.artists.mwm.art_prod }}{{ post.artist }}/{{ post.image }}.svg" />
+        </div>
+
+        <div class="story-text">
+          <h2><span>{{ post.category }}: </span>{% if post.category == "interview" and post.member %}{{ post.member }}{% elsif post.category == "interview" or post.category == "discover" %}{{ site.data.artists[post.artist].name }}{% else %}{{ post.title }}{% endif %}</h2>
+          {% if post.oneliner %}<p class="oneliner">{{ post.oneliner }}</p>{% endif %}
+          {% if post.sponsors %}<p class="sponsor">Sponsored by: {{ post.sponsors }}</p>{% endif %}
+      </div>
+      </article>
+    </a>
+    {% endif %}
+{% endfor %}
+<a href="/archive">
+  <article class="index story">
+    <h2><span>More: </span>Content Archive</h2>
+    <p class="oneliner">Check the archive for lots more content!</p>
+  </article>
+</a>
+
+<!-- <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p> -->

--- a/interviews.html
+++ b/interviews.html
@@ -1,0 +1,39 @@
+---
+layout: splash
+title: Interviews
+artist: mwm
+author: anthony-garone
+image:
+permalink: /archive/interviews
+seo_description:
+seo_keywords:
+---
+
+{% for post in site.posts %}
+  {% if post.front_page == false or post.draft == true %}
+    {% continue %}
+  {% endif %}
+  {% if post.category == 'interview' %}
+    <a href="{{ post.url }}">
+      <article class="{{ post.category }} story">
+        <div class="image-wrap">
+          <img src="{{ site.data.artists.mwm.art_prod }}{{ post.artist }}/{{ post.image }}.svg" />
+        </div>
+
+        <div class="story-text">
+          <h2><span>{{ post.category }}: </span>{% if post.category == "interview" and post.member %}{{ post.member }}{% elsif post.category == "interview" or post.category == "discover" %}{{ site.data.artists[post.artist].name }}{% else %}{{ post.title }}{% endif %}</h2>
+          {% if post.oneliner %}<p class="oneliner">{{ post.oneliner }}</p>{% endif %}
+          {% if post.sponsors %}<p class="sponsor">Sponsored by: {{ post.sponsors }}</p>{% endif %}
+      </div>
+      </article>
+    </a>
+    {% endif %}
+{% endfor %}
+<a href="/archive">
+  <article class="index story">
+    <h2><span>More: </span>Content Archive</h2>
+    <p class="oneliner">Check the archive for lots more content!</p>
+  </article>
+</a>
+
+<!-- <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p> -->

--- a/learn.html
+++ b/learn.html
@@ -1,0 +1,39 @@
+---
+layout: splash
+title: Learn
+artist: mwm
+author: anthony-garone
+image:
+permalink: /archive/learn
+seo_description:
+seo_keywords:
+---
+
+{% for post in site.posts %}
+  {% if post.front_page == false or post.draft == true %}
+    {% continue %}
+  {% endif %}
+  {% if post.category == 'learn' %}
+    <a href="{{ post.url }}">
+      <article class="{{ post.category }} story">
+        <div class="image-wrap">
+          <img src="{{ site.data.artists.mwm.art_prod }}{{ post.artist }}/{{ post.image }}.svg" />
+        </div>
+
+        <div class="story-text">
+          <h2><span>{{ post.category }}: </span>{% if post.category == "interview" and post.member %}{{ post.member }}{% elsif post.category == "interview" or post.category == "discover" %}{{ site.data.artists[post.artist].name }}{% else %}{{ post.title }}{% endif %}</h2>
+          {% if post.oneliner %}<p class="oneliner">{{ post.oneliner }}</p>{% endif %}
+          {% if post.sponsors %}<p class="sponsor">Sponsored by: {{ post.sponsors }}</p>{% endif %}
+      </div>
+      </article>
+    </a>
+    {% endif %}
+{% endfor %}
+<a href="/archive">
+  <article class="index story">
+    <h2><span>More: </span>Content Archive</h2>
+    <p class="oneliner">Check the archive for lots more content!</p>
+  </article>
+</a>
+
+<!-- <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p> -->

--- a/share.html
+++ b/share.html
@@ -1,0 +1,39 @@
+---
+layout: splash
+title: Share
+artist: mwm
+author: anthony-garone
+image:
+permalink: /archive/share
+seo_description:
+seo_keywords:
+---
+
+{% for post in site.posts %}
+  {% if post.front_page == false or post.draft == true %}
+    {% continue %}
+  {% endif %}
+  {% if post.category == 'share' %}
+    <a href="{{ post.url }}">
+      <article class="{{ post.category }} story">
+        <div class="image-wrap">
+          <img src="{{ site.data.artists.mwm.art_prod }}{{ post.artist }}/{{ post.image }}.svg" />
+        </div>
+
+        <div class="story-text">
+          <h2><span>{{ post.category }}: </span>{% if post.category == "interview" and post.member %}{{ post.member }}{% elsif post.category == "interview" or post.category == "discover" %}{{ site.data.artists[post.artist].name }}{% else %}{{ post.title }}{% endif %}</h2>
+          {% if post.oneliner %}<p class="oneliner">{{ post.oneliner }}</p>{% endif %}
+          {% if post.sponsors %}<p class="sponsor">Sponsored by: {{ post.sponsors }}</p>{% endif %}
+      </div>
+      </article>
+    </a>
+    {% endif %}
+{% endfor %}
+<a href="/archive">
+  <article class="index story">
+    <h2><span>More: </span>Content Archive</h2>
+    <p class="oneliner">Check the archive for lots more content!</p>
+  </article>
+</a>
+
+<!-- <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p> -->


### PR DESCRIPTION
Hey Anthony, quick rundown of what was taken care of in this PR - 

- I added a link post type, it'll just show up on the homepage ordered by date like the rest of the posts. You'll just add a file like normal, but it'll just be frontmatter. I have an example one in there now you can build off of. If you want the style changed around, it'd be pretty easy, I just made it as simple as I could for the time being.

- MailChimp div/form's padding and margin was removed. 

- There are now a few pages off the archive
  - /archive/discover
  - /archive/gear
  - /archive/interview
  - /archive/learn
  - /archive/share


  It's important to note this was just done in a non-elegant way, and probably could be improved in the future. It's not filtering anything - just loping through all posts and  only showing the appropriate posts based on category. Also, on those pages I can't seem to figure out how to get the splash image to show correctly, the path it's using on the homepage should work, but isn't. I'll try to look into that. 


Let me know if there's anything you want me to change!


A note about some of the other things we talked about:

- Search feature is plugin related.
- Sitemap just isn't working for me. I'll look into that in the future.
- Pagination shows a (seemingly) random number of posts per page, I left that out of the PR till it's working.